### PR TITLE
IOW-699 Optimize lambdas for memory usage

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,7 @@ provider:
   region: ${opt:region, 'us-west-2'}
   stage: ${opt:stage, 'TEST'}
   runtime: java11
-  memorySize: 768
+  memorySize: 256
   timeout: 60
   logRetentionInDays: 90
   deploymentBucket:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Optimize lambdas for memory usage.

Description
-----------
CloudWatch logs indicate this lambda always uses 219 mb of memory and completes in 2-4 milliseconds.  Shrink max memory to 256 mb.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial